### PR TITLE
Update `Pooch` to version `1.5.2`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pooch" %}
-{% set version = "1.4.0" %}
+{% set version = "1.5.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f827e79ab51b21a8964a4b1ea8972aa4a1079cb9c1ff8e9ec61893eb7dab50cb
+  sha256: 5969b2f1defbdc405df932767e05e0b536e2771c27f1f95d7f260bc99bf13581
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ test:
   requires:
     - pytest
     - pip
+    - python <3.10
   imports:
     - pooch
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - setuptools
     - setuptools_scm
@@ -30,10 +30,12 @@ requirements:
 test:
   requires:
     - pytest
+    - pip
   imports:
     - pooch
   commands:
     - pytest --pyargs pooch.tests.test_integration
+    - pip check
 
 about:
   home: https://github.com/fatiando/pooch


### PR DESCRIPTION
  `pooch` version `1.5.2`
1. - [x] check the upstream
      https://github.com/fatiando/pooch/tree/v1.5.2

2. - [x] check the pinnings

https://github.com/fatiando/pooch/blob/v1.5.2/setup.py

minimal supported `python` version is `3.6`
https://github.com/fatiando/pooch/blob/v1.5.2/setup.py#L60

3. - [x] check the changelogs

https://github.com/fatiando/pooch/blob/v1.5.2/doc/changes.rst

Most of the changes mentioned were bug fixes,  enhancements or documentation updates. 

4. - [x] additional research
    https://github.com/conda-forge/pooch-feedstock/issues

    Currently there are no open issues at the time of the review

5. - [x] verify dev_url
    https://github.com/fatiando/pooch

6. - [x] verify doc_url
    https://www.fatiando.org/pooch

7. - [x] license is spdx compliant
8. - [x] license family
9. - [x] verify the build number
   build number is set to zero
10. - [x] verify setuptools
11. - [x] verify wheel
12. - [x] pip in the test section
    pip was added to the test section
13. - [x] veriy the test section
    the test section was verified
    

Results:
-


Based on the research findings and the results we can conclude
that it is safe to update `pooch` to version `1.5.2`
