### PR TITLE
update to 1.7.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pooch" %}
-{% set version = "1.5.2" %}
+{% set version = "1.7.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5969b2f1defbdc405df932767e05e0b536e2771c27f1f95d7f260bc99bf13581
+  sha256: f174a1041b6447f0eef8860f76d17f60ed2f857dc0efa387a7f08228af05d998
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
@@ -22,16 +21,19 @@ requirements:
     - setuptools_scm
     - wheel
   run:
-    - python >=3.6
-    - requests
-    - packaging
-    - appdirs
+    - python
+    - platformdirs >=2.5.0
+    - packaging >=20.0
+    - requests >=2.19.0
+  run_constrained:
+    - tqdm >=4.41.0,<5.0.0
+    - paramiko >=2.7.0
+    - xxhash >=1.4.3
 
 test:
   requires:
     - pytest
     - pip
-    - python <3.10
   imports:
     - pooch
   commands:


### PR DESCRIPTION
Update to 1.7.0

Required for scikit-image update.

https://github.com/fatiando/pooch/tree/v1.7.0
https://github.com/fatiando/pooch/releases/tag/v1.7.0